### PR TITLE
fix(testing): delete testing container image at end of test

### DIFF
--- a/test/advance.cloudbuild.yaml
+++ b/test/advance.cloudbuild.yaml
@@ -89,7 +89,7 @@ steps:
   args:
     - '-c'
     - |
-      gcloud artifact docker images delete $_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA --quiet
+      gcloud artifacts docker images delete $_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA --quiet
       gcloud run services delete ${_SERVICE_NAME}-$BUILD_ID --region ${_DEPLOY_REGION} --quiet
 
 substitutions:


### PR DESCRIPTION
We use a command at the end of the end-to-end test to delete the container image, then delete the Cloud Run service. The Cloud Run service deletes as expected. Container image delete is silently failing:

From `advance.cloudbuild.yaml`:
```sh
gcloud artifacts docker images delete $_GCR_HOSTNAME/$PROJECT_ID/$_REPOSITORY/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA --quiet
```

From a recent build log:
```
Step #8 - "Delete image and service": ERROR: (gcloud) Invalid choice: 'artifact'.
Step #8 - "Delete image and service": Maybe you meant:
Step #8 - "Delete image and service":   gcloud artifacts
Step #8 - "Delete image and service":   gcloud auth
Step #8 - "Delete image and service": 
Step #8 - "Delete image and service": To search the help text of gcloud commands, run:
Step #8 - "Delete image and service":   gcloud help -- SEARCH_TERMS
```

This failure is ignored, I'm not sure if that's by design, so I am not including adding changes such as `set -e` in this PR.